### PR TITLE
feat(drag-bar): added drag bar to adjust width of code editor and output console

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,3 @@
+.mid-section {
+  display: inline-block
+}

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,4 +1,7 @@
 .mid-section {
   display: inline-block;
-  width: 4em;
+  text-align: center;
+  margin-top: 4em;
+  width: 4%;
+  min-width: 28px;
 }

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,3 +1,4 @@
 .mid-section {
-  display: inline-block
+  display: inline-block;
+  width: 4em;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,7 @@
 <app-navigation-bar></app-navigation-bar>
 <div class="main-section">
   <app-code-editor class="col-5"></app-code-editor>
-  <div class="mid-section col-1">
+  <div class="mid-section">
     <app-drag-bar></app-drag-bar>
   </div>
   <app-output-console class="col-5"></app-output-console>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,8 +1,8 @@
 <app-navigation-bar></app-navigation-bar>
 <div class="main-section">
-  <app-code-editor class="col-5"></app-code-editor>
+  <app-code-editor></app-code-editor>
   <div class="mid-section">
     <app-drag-bar></app-drag-bar>
   </div>
-  <app-output-console class="col-5"></app-output-console>
+  <app-output-console></app-output-console>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,8 @@
 <app-navigation-bar></app-navigation-bar>
 <div class="main-section">
   <app-code-editor class="col-5"></app-code-editor>
+  <div class="col-2">
+    <app-drag-bar></app-drag-bar>
+  </div>
   <app-output-console class="col-5"></app-output-console>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,7 @@
 <app-navigation-bar></app-navigation-bar>
 <div class="main-section">
   <app-code-editor class="col-5"></app-code-editor>
-  <div class="col-2">
+  <div class="mid-section col-1">
     <app-drag-bar></app-drag-bar>
   </div>
   <app-output-console class="col-5"></app-output-console>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -57,11 +57,20 @@ describe('AppComponent', () => {
         expect(mainSectionClass.length).toBe(1);
       });
 
-      it('should have div with class col-2 within main-section', () => {
+      it('should have div with class col-1 within main-section', () => {
 
         const appElement: HTMLElement = fixture.nativeElement;
         const mainSectionClass = appElement.getElementsByClassName('main-section');
-        const divMidSection = mainSectionClass[0].getElementsByClassName('col-2');
+        const divMidSection = mainSectionClass[0].getElementsByClassName('col-1');
+
+        expect(divMidSection.length).toBe(1);
+      });
+
+      it('should have div with class mid-section within main-section', () => {
+
+        const appElement: HTMLElement = fixture.nativeElement;
+        const mainSectionClass = appElement.getElementsByClassName('main-section');
+        const divMidSection = mainSectionClass[0].getElementsByClassName('mid-section');
 
         expect(divMidSection.length).toBe(1);
       });
@@ -104,11 +113,11 @@ describe('AppComponent', () => {
     });
 
     describe('Drag bar tests', () => {
-      it('should contain drag bar component within col-2 div', () => {
+      it('should contain drag bar component within mid-section div', () => {
 
         const appElement: HTMLElement = fixture.nativeElement;
         const mainSectionClass = appElement.getElementsByClassName('main-section');
-        const divMidSection = mainSectionClass[0].getElementsByClassName('col-2');
+        const divMidSection = mainSectionClass[0].getElementsByClassName('mid-section');
         const dragBar = divMidSection[0].querySelector('app-drag-bar');
 
         expect(dragBar).toBeTruthy();

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -56,6 +56,15 @@ describe('AppComponent', () => {
 
         expect(mainSectionClass.length).toBe(1);
       });
+
+      it('should have div with class col-2 within main-section', () => {
+
+        const appElement: HTMLElement = fixture.nativeElement;
+        const mainSectionClass = appElement.getElementsByClassName('main-section');
+        const divMidSection = mainSectionClass[0].getElementsByClassName('col-2');
+
+        expect(divMidSection.length).toBe(1);
+      });
     });
 
     describe('Code editor tests', () => {
@@ -91,6 +100,18 @@ describe('AppComponent', () => {
         const outputConsoleClasses = appElement.querySelector('app-output-console').classList;
 
         expect(outputConsoleClasses[0]).toBe('col-5');
+      });
+    });
+
+    describe('Drag bar tests', () => {
+      it('should contain drag bar component within col-2 div', () => {
+
+        const appElement: HTMLElement = fixture.nativeElement;
+        const mainSectionClass = appElement.getElementsByClassName('main-section');
+        const divMidSection = mainSectionClass[0].getElementsByClassName('col-2');
+        const dragBar = divMidSection[0].querySelector('app-drag-bar');
+
+        expect(dragBar).toBeTruthy();
       });
     });
   });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -57,15 +57,6 @@ describe('AppComponent', () => {
         expect(mainSectionClass.length).toBe(1);
       });
 
-      it('should have div with class col-1 within main-section', () => {
-
-        const appElement: HTMLElement = fixture.nativeElement;
-        const mainSectionClass = appElement.getElementsByClassName('main-section');
-        const divMidSection = mainSectionClass[0].getElementsByClassName('col-1');
-
-        expect(divMidSection.length).toBe(1);
-      });
-
       it('should have div with class mid-section within main-section', () => {
 
         const appElement: HTMLElement = fixture.nativeElement;
@@ -84,14 +75,6 @@ describe('AppComponent', () => {
 
         expect(codeEditor).toBeTruthy();
       });
-
-      it('should have a col-5 class in the code editor component', () => {
-
-        const appElement: HTMLElement = fixture.nativeElement;
-        const outputConsoleClasses = appElement.querySelector('app-code-editor').classList;
-
-        expect(outputConsoleClasses[0]).toBe('col-5');
-      });
     });
 
     describe('Output console tests', () => {
@@ -101,14 +84,6 @@ describe('AppComponent', () => {
         const outputConsole = appElement.querySelector('app-output-console');
 
         expect(outputConsole).toBeTruthy();
-      });
-
-      it('should have a col-5 class in the output console component', () => {
-
-        const appElement: HTMLElement = fixture.nativeElement;
-        const outputConsoleClasses = appElement.querySelector('app-output-console').classList;
-
-        expect(outputConsoleClasses[0]).toBe('col-5');
       });
     });
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,13 +6,15 @@ import { AppComponent } from './app.component';
 import { NavigationBarComponent } from './components/navigation-bar/navigation-bar.component';
 import { CodeEditorComponent } from './components/code-editor/code-editor.component';
 import { OutputConsoleComponent } from './components/output-console/output-console.component';
+import { DragBarComponent } from './components/drag-bar/drag-bar.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     NavigationBarComponent,
     CodeEditorComponent,
-    OutputConsoleComponent
+    OutputConsoleComponent,
+    DragBarComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/code-editor/code-editor.component.css
+++ b/src/app/components/code-editor/code-editor.component.css
@@ -1,7 +1,8 @@
 :host {
   display: inline-block;
   background-color: black;
-  margin: 0.5em 0 0 0.5em;
+  width: 47.2%;
+  margin: 1% 0 0 0.75%;
   padding: 1em 0 1em 0;
   border: 1px solid rgb(63, 63, 63);
   border-radius: 10px;

--- a/src/app/components/code-editor/code-editor.component.spec.ts
+++ b/src/app/components/code-editor/code-editor.component.spec.ts
@@ -1,16 +1,20 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CodeEditorComponent } from './code-editor.component';
+import { WindowSizeService } from 'src/app/services/window-size.service';
 
 describe('CodeEditorComponent', () => {
   let component: CodeEditorComponent;
   let fixture: ComponentFixture<CodeEditorComponent>;
+  let service: WindowSizeService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ CodeEditorComponent ]
     })
     .compileComponents();
+
+    service = TestBed.inject(WindowSizeService);
   }));
 
   beforeEach(() => {
@@ -100,6 +104,73 @@ describe('CodeEditorComponent', () => {
   });
 
   describe('Typescript Tests', () => {
+    describe('windowSizeService width update tests', () => {
+      it(`should start with width style value of "47.2%"`, () => {
+
+        const codeEditorElement: HTMLElement = fixture.nativeElement;
+
+        const expected: string = '47.2%';
+
+        expect(codeEditorElement.style.width).toEqual(expected);
+      });
+
+      it('should have correct width style value when adjustWindowWidths is called with argument 10 pixels', () => {
+
+        const codeEditorElement: HTMLElement = fixture.nativeElement;
+        const helper: WindowSizeHelper = new WindowSizeHelper();
+
+        helper.adjustWindowWidths(10);
+        service.adjustWindowWidths(10);
+
+        fixture.detectChanges();
+
+        const expected: string = helper.expectedEditorWidth.toString() + '%';
+
+        expect(codeEditorElement.style.width).toEqual(expected);
+      });
+
+      it('should have correct width style value when adjustWindowWidths is called with argument -10 pixels', () => {
+
+        const codeEditorElement: HTMLElement = fixture.nativeElement;
+        const helper: WindowSizeHelper = new WindowSizeHelper();
+
+        helper.adjustWindowWidths(-20);
+        service.adjustWindowWidths(-20);
+
+        fixture.detectChanges();
+
+        const expected: string = helper.expectedEditorWidth.toString() + '%';
+
+        expect(codeEditorElement.style.width).toEqual(expected);
+      });
+
+      it(`should have width style value of "64.2%" when adjustWindowWidths is called with argument 10000 pixels`, () => {
+
+        const codeEditorElement: HTMLElement = fixture.nativeElement;
+
+        service.adjustWindowWidths(10000);
+
+        fixture.detectChanges();
+
+        const expected: string = '64.2%';
+
+        expect(codeEditorElement.style.width).toEqual(expected);
+      });
+
+      it(`should have width style value of "30%" when adjustWindowWidths is called with argument -10000 pixels`, () => {
+
+        const codeEditorElement: HTMLElement = fixture.nativeElement;
+
+        service.adjustWindowWidths(-10000);
+
+        fixture.detectChanges();
+
+        const expected: string = '30%';
+
+        expect(codeEditorElement.style.width).toEqual(expected);
+      });
+    });
+
     // TODO: Consider testing the actual KeyBoardEvent of typing which triggers a
     // call to updateLineNumber.
     describe('getLineNumberArray and updateLineNumber tests', () => {
@@ -207,3 +278,25 @@ describe('CodeEditorComponent', () => {
     });
   });
 });
+
+class WindowSizeHelper {
+
+  private changeSensitivity: number = 0.8;
+  private sensitivityDenom: number = 10;
+  private minWidth: number = 30;
+  private maxWidth: number = 64.2;
+  private startWidth: number = 47.2;
+
+  public expectedEditorWidth: number;
+  public expectedOutputWidth: number;
+
+  constructor() {}
+
+  public adjustWindowWidths(deltaXPixels: number) {
+
+    const percentChange: number = deltaXPixels * (this.changeSensitivity / this.sensitivityDenom);
+
+    this.expectedEditorWidth = Math.max(Math.min(this.startWidth + percentChange, this.maxWidth), this.minWidth);
+    this.expectedOutputWidth = Math.max(Math.min(this.startWidth - percentChange, this.maxWidth), this.minWidth);
+  }
+}

--- a/src/app/components/code-editor/code-editor.component.ts
+++ b/src/app/components/code-editor/code-editor.component.ts
@@ -1,16 +1,24 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { WindowSizeService } from './../../services/window-size.service';
+import { Component, ElementRef, ViewChild, OnInit, HostBinding } from '@angular/core';
 
 @Component({
   selector: 'app-code-editor',
   templateUrl: './code-editor.component.html',
   styleUrls: ['./code-editor.component.css']
 })
-export class CodeEditorComponent {
+export class CodeEditorComponent implements OnInit {
 
   private lineNumArray: number[] = [1];
   private lineNumber: number = 1;
   private scrollTop: number;
   @ViewChild('inputRegion') inputRegion: ElementRef<HTMLElement>;
+  @HostBinding('style.width.%') private width: number;
+
+  constructor(private windowSizeService: WindowSizeService) {}
+
+  ngOnInit() {
+    this.windowSizeService.editorCast.subscribe(editorWidth => this.width = editorWidth);
+  }
 
   public updateLineNumber(): void {
 

--- a/src/app/components/drag-bar/drag-bar.component.css
+++ b/src/app/components/drag-bar/drag-bar.component.css
@@ -1,7 +1,3 @@
-:host {
-  margin: 0 25% 0 25%;
-}
-
 .line-bar {
   display: inline-block;
   background-color: rgb(159, 159, 159);
@@ -13,9 +9,9 @@
   display: inline-block;
   width: 0; 
   height: 0; 
-  border-top: 10px solid transparent;
-  border-bottom: 10px solid transparent;
-  border-left: 10px solid rgb(159, 159, 159);
+  border-top: 0.5em solid transparent;
+  border-bottom: 0.5em solid transparent;
+  border-left: 0.5em solid rgb(159, 159, 159);
   margin-left: 4px;
   margin-bottom: 17em;
 }
@@ -24,9 +20,9 @@
   display: inline-block;
   width: 0; 
   height: 0; 
-  border-top: 10px solid transparent;
-  border-bottom: 10px solid transparent; 
-  border-right:10px solid rgb(159, 159, 159);
+  border-top: 0.5em solid transparent;
+  border-bottom: 0.5em solid transparent; 
+  border-right: 0.5em solid rgb(159, 159, 159);
   margin-right: 4px;
   margin-bottom: 17em;
 }

--- a/src/app/components/drag-bar/drag-bar.component.css
+++ b/src/app/components/drag-bar/drag-bar.component.css
@@ -1,0 +1,6 @@
+.line-bar {
+  background-color: rgb(159, 159, 159);
+  width: 2px;
+  height: 34em;
+  margin: 0 0 0 50%;
+}

--- a/src/app/components/drag-bar/drag-bar.component.css
+++ b/src/app/components/drag-bar/drag-bar.component.css
@@ -1,3 +1,7 @@
+:host {
+  cursor: ew-resize;
+}
+
 .line-bar {
   display: inline-block;
   background-color: rgb(159, 159, 159);

--- a/src/app/components/drag-bar/drag-bar.component.css
+++ b/src/app/components/drag-bar/drag-bar.component.css
@@ -1,6 +1,32 @@
+:host {
+  margin: 0 25% 0 25%;
+}
+
 .line-bar {
+  display: inline-block;
   background-color: rgb(159, 159, 159);
   width: 2px;
   height: 34em;
-  margin: 0 0 0 50%;
+}
+
+.arrow-right {
+  display: inline-block;
+  width: 0; 
+  height: 0; 
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  border-left: 10px solid rgb(159, 159, 159);
+  margin-left: 4px;
+  margin-bottom: 17em;
+}
+
+.arrow-left {
+  display: inline-block;
+  width: 0; 
+  height: 0; 
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent; 
+  border-right:10px solid rgb(159, 159, 159);
+  margin-right: 4px;
+  margin-bottom: 17em;
 }

--- a/src/app/components/drag-bar/drag-bar.component.html
+++ b/src/app/components/drag-bar/drag-bar.component.html
@@ -1,1 +1,1 @@
-<p>drag-bar works!</p>
+<div class="line-bar"></div>

--- a/src/app/components/drag-bar/drag-bar.component.html
+++ b/src/app/components/drag-bar/drag-bar.component.html
@@ -1,0 +1,1 @@
+<p>drag-bar works!</p>

--- a/src/app/components/drag-bar/drag-bar.component.html
+++ b/src/app/components/drag-bar/drag-bar.component.html
@@ -1,1 +1,3 @@
+<div class="arrow-left"></div>
 <div class="line-bar"></div>
+<div class="arrow-right"></div>

--- a/src/app/components/drag-bar/drag-bar.component.spec.ts
+++ b/src/app/components/drag-bar/drag-bar.component.spec.ts
@@ -1,16 +1,20 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DragBarComponent } from './drag-bar.component';
+import { WindowSizeService } from 'src/app/services/window-size.service';
 
 describe('DragBarComponent', () => {
   let component: DragBarComponent;
   let fixture: ComponentFixture<DragBarComponent>;
+  let service: WindowSizeService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ DragBarComponent ]
     })
     .compileComponents();
+
+    service = TestBed.inject(WindowSizeService);
   }));
 
   beforeEach(() => {
@@ -49,6 +53,206 @@ describe('DragBarComponent', () => {
         const arrowRightClasses = dragBarElement.getElementsByClassName('arrow-right');
 
         expect(arrowRightClasses.length).toBe(1);
+      });
+    });
+  });
+
+  describe('Typescript tests', () => {
+    describe('HostListener method call tests.', () => {
+      it('should call the onPointerDown method when mouse is down on drag bar position.', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+
+        spyOn(component, 'onPointerDown');
+
+        const pointerDownEvent = new PointerEvent('pointerdown');
+
+        dragBarElement.dispatchEvent(pointerDownEvent);
+
+        fixture.detectChanges();
+
+        expect(component.onPointerDown).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not call the onPointerDown method when mouse is down away from drag bar position.', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+
+        spyOn(component, 'onPointerDown');
+
+        const pointerDownEvent = new PointerEvent('pointerdown');
+
+        dragBarElement.ownerDocument.dispatchEvent(pointerDownEvent);
+
+        fixture.detectChanges();
+
+        expect(component.onPointerDown).toHaveBeenCalledTimes(0);
+      });
+
+      it('should call the onPointerUp method when mouse is up at any position.', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+
+        spyOn(component, 'onPointerUp');
+
+        const pointerUpEvent = new PointerEvent('pointerup');
+
+        dragBarElement.ownerDocument.dispatchEvent(pointerUpEvent);
+
+        fixture.detectChanges();
+
+        expect(component.onPointerUp).toHaveBeenCalledTimes(1);
+      });
+
+      it('should call the onPointerMove method when mouse is moving at any position.', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+
+        spyOn(component, 'onPointerMove');
+
+        const pointerMoveEvent = new PointerEvent('pointermove');
+
+        dragBarElement.ownerDocument.dispatchEvent(pointerMoveEvent);
+
+        fixture.detectChanges();
+
+        expect(component.onPointerMove).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('adjustWindowWidths call tests', () => {
+      it('should call adjustWindowWidths once if pointer is down and then moving', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+
+        spyOn(service, 'adjustWindowWidths');
+
+        const pointerDownEvent = new PointerEvent('pointerdown');
+        const pointerMoveEvent = new PointerEvent('pointermove');
+
+        dragBarElement.dispatchEvent(pointerDownEvent);
+        dragBarElement.ownerDocument.dispatchEvent(pointerMoveEvent);
+
+        fixture.detectChanges();
+
+        expect(service.adjustWindowWidths).toHaveBeenCalledTimes(1);
+      });
+
+      it('should call adjustWindowWidths twice if pointer is down, then moving, then up, twice', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+
+        spyOn(service, 'adjustWindowWidths');
+
+        const pointerDownEvent = new PointerEvent('pointerdown');
+        const pointerMoveEvent = new PointerEvent('pointermove');
+        const pointerUpEvent = new PointerEvent('pointerup');
+
+        dragBarElement.dispatchEvent(pointerDownEvent);
+        dragBarElement.ownerDocument.dispatchEvent(pointerMoveEvent);
+        dragBarElement.ownerDocument.dispatchEvent(pointerUpEvent);
+        dragBarElement.dispatchEvent(pointerDownEvent);
+        dragBarElement.ownerDocument.dispatchEvent(pointerMoveEvent);
+        dragBarElement.ownerDocument.dispatchEvent(pointerUpEvent);
+
+        fixture.detectChanges();
+
+        expect(service.adjustWindowWidths).toHaveBeenCalledTimes(2);
+      });
+
+      it('should call adjustWindowWidths three times if pointer is down and then moving three times', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+
+        spyOn(service, 'adjustWindowWidths');
+
+        const pointerDownEvent = new PointerEvent('pointerdown');
+        const pointerMoveEvent = new PointerEvent('pointermove');
+
+        dragBarElement.dispatchEvent(pointerDownEvent);
+        dragBarElement.ownerDocument.dispatchEvent(pointerMoveEvent);
+        dragBarElement.ownerDocument.dispatchEvent(pointerMoveEvent);
+        dragBarElement.ownerDocument.dispatchEvent(pointerMoveEvent);
+
+        fixture.detectChanges();
+
+        expect(service.adjustWindowWidths).toHaveBeenCalledTimes(3);
+      });
+
+      it('should call adjustWindowWidths once if pointer is down, then moves, then goes up, then moves', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+
+        spyOn(service, 'adjustWindowWidths');
+
+        const pointerDownEvent = new PointerEvent('pointerdown');
+        const pointerMoveEvent = new PointerEvent('pointermove');
+        const pointerUpEvent = new PointerEvent('pointerup');
+
+        dragBarElement.dispatchEvent(pointerDownEvent);
+        dragBarElement.ownerDocument.dispatchEvent(pointerMoveEvent);
+        dragBarElement.ownerDocument.dispatchEvent(pointerUpEvent);
+        dragBarElement.ownerDocument.dispatchEvent(pointerMoveEvent);
+
+        fixture.detectChanges();
+
+        expect(service.adjustWindowWidths).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not call adjustWindowWidths if pointer is down without moving', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+
+        spyOn(service, 'adjustWindowWidths');
+
+        const pointerDownEvent = new PointerEvent('pointerdown');
+
+        dragBarElement.dispatchEvent(pointerDownEvent);
+
+        fixture.detectChanges();
+
+        expect(service.adjustWindowWidths).toHaveBeenCalledTimes(0);
+      });
+
+      it('should not call adjustWindowWidths if pointer is down then immediately up', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+
+        spyOn(service, 'adjustWindowWidths');
+
+        const pointerDownEvent = new PointerEvent('pointerdown');
+        const pointerUpEvent = new PointerEvent('pointerup');
+
+        dragBarElement.dispatchEvent(pointerDownEvent);
+        dragBarElement.ownerDocument.dispatchEvent(pointerUpEvent);
+
+        fixture.detectChanges();
+
+        expect(service.adjustWindowWidths).toHaveBeenCalledTimes(0);
+      });
+
+      it('should not call adjustWindowWidths if pointer moving without being down', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+
+        spyOn(service, 'adjustWindowWidths');
+
+        const pointerMoveEvent = new PointerEvent('pointermove');
+
+        dragBarElement.ownerDocument.dispatchEvent(pointerMoveEvent);
+
+        fixture.detectChanges();
+
+        expect(service.adjustWindowWidths).toHaveBeenCalledTimes(0);
+      });
+
+      it('should not call adjustWindowWidths no event occurs', () => {
+
+        spyOn(service, 'adjustWindowWidths');
+
+        fixture.detectChanges();
+
+        expect(service.adjustWindowWidths).toHaveBeenCalledTimes(0);
       });
     });
   });

--- a/src/app/components/drag-bar/drag-bar.component.spec.ts
+++ b/src/app/components/drag-bar/drag-bar.component.spec.ts
@@ -34,6 +34,22 @@ describe('DragBarComponent', () => {
 
         expect(lineBarClasses.length).toBe(1);
       });
+
+      it('should create a div with class arrow-left.', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+        const arrowLeftClasses = dragBarElement.getElementsByClassName('arrow-left');
+
+        expect(arrowLeftClasses.length).toBe(1);
+      });
+
+      it('should create a div with class arrow-right.', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+        const arrowRightClasses = dragBarElement.getElementsByClassName('arrow-right');
+
+        expect(arrowRightClasses.length).toBe(1);
+      });
     });
   });
 });

--- a/src/app/components/drag-bar/drag-bar.component.spec.ts
+++ b/src/app/components/drag-bar/drag-bar.component.spec.ts
@@ -19,7 +19,21 @@ describe('DragBarComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('HTML tests', () => {
+    describe('Main component', () => {
+      it('should create', () => {
+        expect(component).toBeTruthy();
+      });
+    });
+
+    describe('Line bar tests.', () => {
+      it('should create a div with class line-bar.', () => {
+
+        const dragBarElement: HTMLElement = fixture.nativeElement;
+        const lineBarClasses = dragBarElement.getElementsByClassName('line-bar');
+
+        expect(lineBarClasses.length).toBe(1);
+      });
+    });
   });
 });

--- a/src/app/components/drag-bar/drag-bar.component.spec.ts
+++ b/src/app/components/drag-bar/drag-bar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DragBarComponent } from './drag-bar.component';
+
+describe('DragBarComponent', () => {
+  let component: DragBarComponent;
+  let fixture: ComponentFixture<DragBarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DragBarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DragBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/drag-bar/drag-bar.component.ts
+++ b/src/app/components/drag-bar/drag-bar.component.ts
@@ -1,8 +1,40 @@
-import { Component } from '@angular/core';
+import { WindowSizeService } from './../../services/window-size.service';
+import { Component, OnInit, HostListener } from '@angular/core';
 
 @Component({
   selector: 'app-drag-bar',
   templateUrl: './drag-bar.component.html',
   styleUrls: ['./drag-bar.component.css']
 })
-export class DragBarComponent {}
+export class DragBarComponent implements OnInit {
+
+  private isDragging: boolean;
+  private prevMouseX: number;
+
+  constructor(private windowSizeService: WindowSizeService) {}
+
+  ngOnInit() {
+    this.isDragging = false;
+  }
+
+  @HostListener('pointerdown', ['$event'])
+  onPointerDown(event) {
+    this.isDragging = true;
+    this.prevMouseX = event.clientX;
+  }
+
+  @HostListener('document:pointerup', ['$event'])
+  onPointerUp(event) {
+    this.isDragging = false;
+  }
+
+  @HostListener('document:pointermove', ['$event'])
+  onPointerMove(event) {
+    if (this.isDragging) {
+      const deltaXPixels: number = event.clientX - this.prevMouseX;
+      this.prevMouseX = event.clientX;
+
+      this.windowSizeService.adjustWindowWidths(deltaXPixels);
+    }
+  }
+}

--- a/src/app/components/drag-bar/drag-bar.component.ts
+++ b/src/app/components/drag-bar/drag-bar.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-drag-bar',
+  templateUrl: './drag-bar.component.html',
+  styleUrls: ['./drag-bar.component.css']
+})
+export class DragBarComponent {}

--- a/src/app/components/output-console/output-console.component.css
+++ b/src/app/components/output-console/output-console.component.css
@@ -1,7 +1,7 @@
 :host {
   display: inline-block;
   background-color: black;
-  margin: 0.5em 0 0 0.5em;
+  margin: 0.5em 0 0 0em;
   padding: 1em 0 1em 0;
   border: 1px solid rgb(63, 63, 63);
   border-radius: 10px;

--- a/src/app/components/output-console/output-console.component.css
+++ b/src/app/components/output-console/output-console.component.css
@@ -1,7 +1,7 @@
 :host {
   display: inline-block;
   background-color: black;
-  margin: 0.5em 0 0 0em;
+  width: 47.2%;
   padding: 1em 0 1em 0;
   border: 1px solid rgb(63, 63, 63);
   border-radius: 10px;

--- a/src/app/components/output-console/output-console.component.spec.ts
+++ b/src/app/components/output-console/output-console.component.spec.ts
@@ -1,3 +1,4 @@
+import { WindowSizeService } from './../../services/window-size.service';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { OutputConsoleComponent } from './output-console.component';
@@ -5,12 +6,15 @@ import { OutputConsoleComponent } from './output-console.component';
 describe('OutputConsoleComponent', () => {
   let component: OutputConsoleComponent;
   let fixture: ComponentFixture<OutputConsoleComponent>;
+  let service: WindowSizeService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ OutputConsoleComponent ]
     })
     .compileComponents();
+
+    service = TestBed.inject(WindowSizeService);
   }));
 
   beforeEach(() => {
@@ -74,6 +78,73 @@ describe('OutputConsoleComponent', () => {
   });
 
   describe('Typescript tests', () => {
+    describe('windowSizeService width update tests', () => {
+      it(`should start with width style value of "47.2%"`, () => {
+
+        const outputConsoleElement: HTMLElement = fixture.nativeElement;
+
+        const expected: string = '47.2%';
+
+        expect(outputConsoleElement.style.width).toEqual(expected);
+      });
+
+      it('should have correct width style value when adjustWindowWidths is called with argument 20 pixels', () => {
+
+        const outputConsoleElement: HTMLElement = fixture.nativeElement;
+        const helper: WindowSizeHelper = new WindowSizeHelper();
+
+        helper.adjustWindowWidths(20);
+        service.adjustWindowWidths(20);
+
+        fixture.detectChanges();
+
+        const expected: string = helper.expectedOutputWidth.toString() + '%';
+
+        expect(outputConsoleElement.style.width).toEqual(expected);
+      });
+
+      it('should have correct width style value when adjustWindowWidths is called with argument -10 pixels', () => {
+
+        const outputConsoleElement: HTMLElement = fixture.nativeElement;
+        const helper: WindowSizeHelper = new WindowSizeHelper();
+
+        helper.adjustWindowWidths(-10);
+        service.adjustWindowWidths(-10);
+
+        fixture.detectChanges();
+
+        const expected: string = helper.expectedOutputWidth.toString() + '%';
+
+        expect(outputConsoleElement.style.width).toEqual(expected);
+      });
+
+      it(`should have width style value of "30%" when adjustWindowWidths is called with argument 10000 pixels`, () => {
+
+        const outputConsoleElement: HTMLElement = fixture.nativeElement;
+
+        service.adjustWindowWidths(10000);
+
+        fixture.detectChanges();
+
+        const expected: string = '30%';
+
+        expect(outputConsoleElement.style.width).toEqual(expected);
+      });
+
+      it(`should have width style value of "64.2%" when adjustWindowWidths is called with argument -10000 pixels`, () => {
+
+        const outputConsoleElement: HTMLElement = fixture.nativeElement;
+
+        service.adjustWindowWidths(-10000);
+
+        fixture.detectChanges();
+
+        const expected: string = '64.2%';
+
+        expect(outputConsoleElement.style.width).toEqual(expected);
+      });
+    });
+
     describe('outputText tests', () => {
       it('should have empty innerHTML when output console initialised.', () => {
 
@@ -135,3 +206,25 @@ describe('OutputConsoleComponent', () => {
     });
   });
 });
+
+class WindowSizeHelper {
+
+  private changeSensitivity: number = 0.8;
+  private sensitivityDenom: number = 10;
+  private minWidth: number = 30;
+  private maxWidth: number = 64.2;
+  private startWidth: number = 47.2;
+
+  public expectedEditorWidth: number;
+  public expectedOutputWidth: number;
+
+  constructor() {}
+
+  public adjustWindowWidths(deltaXPixels: number) {
+
+    const percentChange: number = deltaXPixels * (this.changeSensitivity / this.sensitivityDenom);
+
+    this.expectedEditorWidth = Math.max(Math.min(this.startWidth + percentChange, this.maxWidth), this.minWidth);
+    this.expectedOutputWidth = Math.max(Math.min(this.startWidth - percentChange, this.maxWidth), this.minWidth);
+  }
+}

--- a/src/app/components/output-console/output-console.component.ts
+++ b/src/app/components/output-console/output-console.component.ts
@@ -1,13 +1,21 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { WindowSizeService } from './../../services/window-size.service';
+import { Component, OnInit, HostBinding } from '@angular/core';
 
 @Component({
   selector: 'app-output-console',
   templateUrl: './output-console.component.html',
   styleUrls: ['./output-console.component.css']
 })
-export class OutputConsoleComponent {
+export class OutputConsoleComponent implements OnInit {
 
+  @HostBinding('style.width.%') private width: number;
   private output: string = '';
+
+  constructor(private windowSizeService: WindowSizeService) {}
+
+  ngOnInit() {
+    this.windowSizeService.outputCast.subscribe(outputWidth => this.width = outputWidth);
+  }
 
   public outputText(htmlText: string): void {
     this.output = htmlText;

--- a/src/app/services/window-size.service.spec.ts
+++ b/src/app/services/window-size.service.spec.ts
@@ -1,0 +1,151 @@
+import { TestBed } from '@angular/core/testing';
+
+import { WindowSizeService } from './window-size.service';
+
+describe('WindowSizeService', () => {
+  let service: WindowSizeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(WindowSizeService);
+  });
+
+  describe('Main service test', () => {
+    it('should be created', () => {
+      expect(service).toBeTruthy();
+    });
+
+    it('should be instantiated with editor of width 47.2 percent', () => {
+
+      let editorWidth: number;
+      const expected: number = 47.2;
+
+      service.editorCast.subscribe(width => editorWidth = width);
+
+      expect(editorWidth).toEqual(expected);
+    });
+
+    it('should be instantiated with output console width of 47.2 percent', () => {
+
+      let outputWidth: number;
+      const expected: number = 47.2;
+
+      service.outputCast.subscribe(width => outputWidth = width);
+
+      expect(outputWidth).toEqual(expected);
+    });
+  });
+
+  describe('adjustWindowWidths tests', () => {
+    it('should give 47.2 percent for both editor and output width if change in x movement is 0 pixels after initialisation', () => {
+
+      let editorWidth: number;
+      let outputWidth: number;
+
+      const expectedEditorWidthPercent: number = 47.2;
+      const expectedOutputWidthPercent: number = 47.2;
+
+      const deltaXPixels: number = 0;
+
+      service.adjustWindowWidths(deltaXPixels);
+
+      service.editorCast.subscribe(width => editorWidth = width);
+      service.outputCast.subscribe(width => outputWidth = width);
+
+      expect(editorWidth).toEqual(expectedEditorWidthPercent);
+      expect(outputWidth).toEqual(expectedOutputWidthPercent);
+    });
+
+    it('should give correct width for editor and output if change in x movement is 20 pixels', () => {
+
+      const helper: Helper = new Helper();
+
+      helper.adjustWindowWidths(20);
+
+      service.adjustWindowWidths(20);
+
+      let editorWidth: number;
+      let outputWidth: number;
+
+      service.editorCast.subscribe(width => editorWidth = width);
+      service.outputCast.subscribe(width => outputWidth = width);
+
+      expect(editorWidth).toEqual(helper.expectedEditorWidth);
+      expect(outputWidth).toEqual(helper.expectedOutputWidth);
+    });
+
+    it('should give correct width for editor and output if change in x movement is -15 pixels', () => {
+
+      const helper: Helper = new Helper();
+
+      helper.adjustWindowWidths(-15);
+
+      service.adjustWindowWidths(-15);
+
+      let editorWidth: number;
+      let outputWidth: number;
+
+      service.editorCast.subscribe(width => editorWidth = width);
+      service.outputCast.subscribe(width => outputWidth = width);
+
+      expect(editorWidth).toEqual(helper.expectedEditorWidth);
+      expect(outputWidth).toEqual(helper.expectedOutputWidth);
+    });
+
+    it('should limit width percent to 64.2 for editor and 30 for output if change in x movement is high positive value', () => {
+
+      const expectedEditorWidth: number = 64.2;
+      const expectedOutputWidth: number = 30;
+
+      service.adjustWindowWidths(10000);
+
+      let editorWidth: number;
+      let outputWidth: number;
+
+      service.editorCast.subscribe(width => editorWidth = width);
+      service.outputCast.subscribe(width => outputWidth = width);
+
+      expect(editorWidth).toEqual(expectedEditorWidth);
+      expect(outputWidth).toEqual(expectedOutputWidth);
+    });
+
+    it('should limit width percent to 30 for editor and 64.2 for output if change in x movement is high negative value', () => {
+
+      const expectedEditorWidth: number = 30;
+      const expectedOutputWidth: number = 64.2;
+
+      service.adjustWindowWidths(-10000);
+
+      let editorWidth: number;
+      let outputWidth: number;
+
+      service.editorCast.subscribe(width => editorWidth = width);
+      service.outputCast.subscribe(width => outputWidth = width);
+
+      expect(editorWidth).toEqual(expectedEditorWidth);
+      expect(outputWidth).toEqual(expectedOutputWidth);
+    });
+  });
+});
+
+class Helper {
+
+  private changeSensitivity: number = 0.8;
+  private sensitivityDenom: number = 10;
+  private minWidth: number = 30;
+  private maxWidth: number = 64.2;
+  private startWidth: number = 47.2;
+
+  public expectedEditorWidth: number;
+  public expectedOutputWidth: number;
+
+  constructor() {}
+
+  public adjustWindowWidths(deltaXPixels: number) {
+
+    const percentChange: number = deltaXPixels * (this.changeSensitivity / this.sensitivityDenom);
+
+    this.expectedEditorWidth = Math.max(Math.min(this.startWidth + percentChange, this.maxWidth), this.minWidth);
+    this.expectedOutputWidth = Math.max(Math.min(this.startWidth - percentChange, this.maxWidth), this.minWidth);
+  }
+}

--- a/src/app/services/window-size.service.ts
+++ b/src/app/services/window-size.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class WindowSizeService {
+
+  private readonly SENSITIVITY_DENOMINATOR: number = 10;
+  private readonly MIN_WIDTH_PERCENT: number = 30;
+  private readonly MAX_WIDTH_PERCENT: number = 64.2;
+  private readonly START_WIDTH_PERCENT: number = 47.2;
+
+  private editorWidth: BehaviorSubject<number>;
+  private outputConsoleWidth: BehaviorSubject<number>;
+  private changeSensitivity: number;
+
+  public editorCast: Observable<number>;
+  public outputCast: Observable<number>;
+
+  constructor() {
+
+    this.editorWidth = new BehaviorSubject(this.START_WIDTH_PERCENT);
+    this.outputConsoleWidth = new BehaviorSubject(this.START_WIDTH_PERCENT);
+    this.changeSensitivity = 0.8;
+
+    this.editorCast = this.editorWidth.asObservable();
+    this.outputCast = this.outputConsoleWidth.asObservable();
+  }
+
+  public adjustWindowWidths(deltaXPixels: number): void {
+
+    const editorWidthVal: number = this.editorWidth.getValue();
+    const outputWidthVal: number = this.outputConsoleWidth.getValue();
+
+    const percentChange: number = deltaXPixels * (this.changeSensitivity / this.SENSITIVITY_DENOMINATOR);
+
+    // Calculate width percent and bound it between min and max width
+    const newEditorWidth: number = Math.max(Math.min(editorWidthVal + percentChange, this.MAX_WIDTH_PERCENT), this.MIN_WIDTH_PERCENT);
+    const newOutputWidth: number = Math.max(Math.min(outputWidthVal - percentChange, this.MAX_WIDTH_PERCENT), this.MIN_WIDTH_PERCENT);
+
+    this.editorWidth.next(newEditorWidth);
+    this.outputConsoleWidth.next(newOutputWidth);
+  }
+}


### PR DESCRIPTION
Added a drag bar at the centre of the page in between the code editor and output console. The drag bar can be clicked and dragged to adjust the width of the code editor and output console. The widths of each is limited to a minimum of 30% of the page width and maximum of 64.2% of page width. The icon of the mouse/pointer changes when hovering over the drag bar to signal to the user that they can start dragging the component.